### PR TITLE
chore: Added clap.rs library version 2.32.0 to cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["matthieusb <sauboua.beneluz.matthieu@gmail.com>"]
 
 [dependencies]
+clap = "2.32.0"


### PR DESCRIPTION
closes #2